### PR TITLE
feat: use common user agent format

### DIFF
--- a/Client.UnitTests/RequestMetadataTest.cs
+++ b/Client.UnitTests/RequestMetadataTest.cs
@@ -22,8 +22,7 @@ namespace Zeebe.Client
 
             var entry = sendMetadata[0];
             Assert.AreEqual("user-agent", entry.Key);
-            Assert.IsTrue(entry.Value.Contains("csharp"));
-            Assert.IsTrue(entry.Value.Contains(typeof(ZeebeClient).Assembly.GetName().Version.ToString()));
+            Assert.IsTrue(entry.Value.StartsWith("zeebe-client-csharp/" + typeof(ZeebeClient).Assembly.GetName().Version));
         }
     }
 }

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -56,7 +56,8 @@ namespace Zeebe.Client
             this.loggerFactory = loggerFactory;
 
             var channelOptions = new List<ChannelOption>();
-            var userAgentString = "client: csharp, version: " + typeof(ZeebeClient).Assembly.GetName().Version;
+            var clientVersion = typeof(ZeebeClient).Assembly.GetName().Version;
+            var userAgentString = $"zeebe-client-csharp/{clientVersion}";
             var userAgentOption = new ChannelOption(ChannelOptions.PrimaryUserAgentString, userAgentString);
             channelOptions.Add(userAgentOption);
 


### PR DESCRIPTION
Unify the user agment format, which is used by the Zeebe clients.

closes #144
