### PR TITLE
RetryBackOff param for FailJobCommand

### DIFF
--- a/Client/Api/Commands/IFailJobCommandStep1.cs
+++ b/Client/Api/Commands/IFailJobCommandStep1.cs
@@ -47,5 +47,16 @@ namespace Zeebe.Client.Api.Commands
         ///     to the broker.
         ///     </returns>
         IFailJobCommandStep2 ErrorMessage(string errorMsg);
+
+        /// <summary>
+        /// Set the backoff timeout for the next retry of this job.
+        ///
+        /// </summary>
+        ///
+        /// <param name="retryBackOff">the backoff timeout (in ms) for the next retry of this job.</param>
+        /// <returns>the builder for this command. Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
+        ///     to the broker.
+        /// </returns>
+        IFailJobCommandStep2 RetryBackOff(long retryBackOff);
     }
 }

--- a/Client/Impl/Commands/FailJobCommand.cs
+++ b/Client/Impl/Commands/FailJobCommand.cs
@@ -53,6 +53,12 @@ namespace Zeebe.Client.Impl.Commands
             return this;
         }
 
+        public IFailJobCommandStep2 RetryBackOff(long retryBackOff)
+        {
+            request.RetryBackOff = retryBackOff;
+            return this;
+        }
+
         public async Task<IFailJobResponse> Send(TimeSpan? timeout = null, CancellationToken token = default)
         {
             var asyncReply = gatewayClient.FailJobAsync(request, deadline: timeout?.FromUtcNow(), cancellationToken: token);


### PR DESCRIPTION
In order to set backoff timeout parameter existing in grpc request I added retryBackOff parameter to FailJobCommand.