### PR TITLE
feat: Update Testcontainers for .NET

### DIFF
--- a/Client.IntegrationTests/Client.IntegrationTests.csproj
+++ b/Client.IntegrationTests/Client.IntegrationTests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.19" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="5.1.0" />
@@ -14,7 +13,7 @@
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="TestContainers" Version="0.0.2.107" />
+    <PackageReference Include="TestContainers" Version="2.3.0" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Updates the Testcontainers for .NET NuGet dependency to its latest release. Assigns a random host port to the service running inside a container (best practice). Resolve the hostname instead of a fixed value (endpoint my differ due to the Docker environment, Testcontainers resolves the right endpoint).

## Why is it important?

I noticed you are using an outdated version. The version is probably not compatible with Docker Desktop, etc. anymore. To leverage Testcontainesr into your test environment, I recommend the latest release.

If you have issues setting up Testcontinaers, let me know. I am happy to help. While I was browsing through the source code I noticed some parts that can be improved. I addressed some of them immediately.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->