### PR TITLE
Migrate to .net 7.0

### DIFF
--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -7,9 +7,9 @@ jobs:
     - run: docker pull camunda/zeebe:1.0.0
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: 7.x
     - name: Build
       run: dotnet build --configuration Release
     - name: Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,9 @@ jobs:
     - run: docker pull camunda/zeebe:8.1.3
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: 7.x
     - name: Build 
       run: dotnet build --configuration Release      
     - name: Test

--- a/Client.Cloud.Example/Client.Cloud.Example.csproj
+++ b/Client.Cloud.Example/Client.Cloud.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>

--- a/Client.Examples/Client.Examples.csproj
+++ b/Client.Examples/Client.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Client.Examples/Client.Examples.csproj
+++ b/Client.Examples/Client.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.19" />
     <PackageReference Include="Newtonsoft.Json" version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.2" />

--- a/Client.IntegrationTests/Client.IntegrationTests.csproj
+++ b/Client.IntegrationTests/Client.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Client.IntegrationTests/Client.IntegrationTests.csproj
+++ b/Client.IntegrationTests/Client.IntegrationTests.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.19" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.2" />

--- a/Client.UnitTests/Client.UnitTests.csproj
+++ b/Client.UnitTests/Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Zeebe.Client</RootNamespace>
   </PropertyGroup>
 

--- a/Client.UnitTests/Client.UnitTests.csproj
+++ b/Client.UnitTests/Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Zeebe.Client</RootNamespace>
   </PropertyGroup>
 

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Version>1.3.0</Version>
     <Authors>Christopher Zell</Authors>
     <Company />
@@ -122,6 +122,7 @@ This release is based on the Zeebe 8.1.X release (https://github.com/zeebe-io/ze
     <PackageVersion>1.3.0</PackageVersion>
     <RootNamespace>Zeebe.Client</RootNamespace>
     <Title>1.3.0</Title>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.3.0</Version>
     <Authors>Christopher Zell</Authors>
     <Company />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
relates to #517 
relates to #348 
relates to https://github.com/camunda-community-hub/zeebe-client-csharp/issues/277

First part of migrating to grpc-dotnet is to migrate to the latest .net version. Migrating to .net 7.0 since that is the latest version, which is still supported all others are already eol https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core.