### PR TITLE
Migrate to grpc.net.client

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -129,7 +129,7 @@ This release is based on the Zeebe 8.1.X release (https://github.com/zeebe-io/ze
     <PackageReference Include="Google.Protobuf" version="3.23.4" />
     <PackageReference Include="Grpc" version="2.46.6" />
     <PackageReference Include="Grpc.Auth" Version="2.55.0" />
-    <PackageReference Include="Grpc.Core" version="2.46.6" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.55.0" />
     <PackageReference Include="Grpc.Tools" version="2.56.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Grpc.Core is deprecated and should no longer be used https://grpc.io/blog/grpc-csharp-future/

closes https://github.com/camunda-community-hub/zeebe-client-csharp/issues/348
closes https://github.com/camunda-community-hub/zeebe-client-csharp/issues/194

