### PR TITLE
Updated DeployResourceCommand to support TenantId.

### DIFF
--- a/Client.UnitTests/DeploymentTest.cs
+++ b/Client.UnitTests/DeploymentTest.cs
@@ -339,5 +339,31 @@ namespace Zeebe.Client
             Assert.AreEqual("nameRequirement", decisionRequirementsMetadata.DmnDecisionRequirementsName);
             Assert.AreEqual("id", decisionRequirementsMetadata.DmnDecisionRequirementsId);
         }
+
+        [Test]
+        public async Task ShouldSetTenantIdAsExpected()
+        {
+            // given
+            var expectedRequest = new DeployResourceRequest
+            {
+                TenantId = "1234",
+                Resources =
+                {
+                    new Resource
+                    {
+                        Content = ByteString.FromStream(File.OpenRead(_demoProcessPath)),
+                        Name = _demoProcessPath
+                    }
+                }
+            };
+
+            // when
+            await ZeebeClient.NewDeployCommand().AddTenantId("1234").AddResourceFile(_demoProcessPath).Send();
+
+            // then
+            var actualRequest = TestService.Requests[typeof(DeployResourceRequest)][0];
+
+            Assert.AreEqual(expectedRequest, actualRequest);
+        }
     }
 }

--- a/Client.UnitTests/DeploymentTest.cs
+++ b/Client.UnitTests/DeploymentTest.cs
@@ -358,7 +358,7 @@ namespace Zeebe.Client
             };
 
             // when
-            await ZeebeClient.NewDeployCommand().AddTenantId("1234").AddResourceFile(_demoProcessPath).Send();
+            await ZeebeClient.NewDeployCommand().AddResourceFile(_demoProcessPath).AddTenantId("1234").Send();
 
             // then
             var actualRequest = TestService.Requests[typeof(DeployResourceRequest)][0];

--- a/Client/Api/Commands/IDeployResourceCommandStep1.cs
+++ b/Client/Api/Commands/IDeployResourceCommandStep1.cs
@@ -18,7 +18,7 @@ using Zeebe.Client.Api.Responses;
 
 namespace Zeebe.Client.Api.Commands
 {
-    public interface IDeployResourceCommandStep1
+    public interface IDeployResourceCommandStep1 : ITenantIdCommandStep<IDeployResourceCommandBuilderStep2>
     {
         /// <summary>
         /// Add the given resource to the deployment.

--- a/Client/Api/Commands/IDeployResourceCommandStep1.cs
+++ b/Client/Api/Commands/IDeployResourceCommandStep1.cs
@@ -18,7 +18,7 @@ using Zeebe.Client.Api.Responses;
 
 namespace Zeebe.Client.Api.Commands
 {
-    public interface IDeployResourceCommandStep1 : ITenantIdCommandStep<IDeployResourceCommandBuilderStep2>
+    public interface IDeployResourceCommandStep1
     {
         /// <summary>
         /// Add the given resource to the deployment.
@@ -70,7 +70,7 @@ namespace Zeebe.Client.Api.Commands
         IDeployResourceCommandBuilderStep2 AddResourceFile(string filename);
     }
 
-    public interface IDeployResourceCommandBuilderStep2 : IDeployResourceCommandStep1, IFinalCommandWithRetryStep<IDeployResourceResponse>
+    public interface IDeployResourceCommandBuilderStep2 : IDeployResourceCommandStep1, ITenantIdCommandStep<IDeployResourceCommandBuilderStep2>, IFinalCommandWithRetryStep<IDeployResourceResponse>
     {
         // the place for new optional parameters
     }

--- a/Client/Api/Commands/ITenantIdCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdCommandStep.cs
@@ -1,0 +1,13 @@
+namespace Zeebe.Client.Api.Commands
+{
+    public interface ITenantIdCommandStep<out T>
+    {
+        /// <summary>
+        /// Set the tenantId for the resource.
+        /// </summary>
+        /// <param name="tenantId">the tenantId to associate to this resource</param>
+        /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
+        ///     to the broker.</returns>
+        T AddTenantId(string tenantId);
+    }
+}

--- a/Client/Impl/Commands/DeployResourceCommand.cs
+++ b/Client/Impl/Commands/DeployResourceCommand.cs
@@ -73,6 +73,12 @@ namespace Zeebe.Client.Impl.Commands
             return this;
         }
 
+        public IDeployResourceCommandBuilderStep2 AddTenantId(string tenantId)
+        {
+            request.TenantId = tenantId;
+            return this;
+        }
+
         public async Task<IDeployResourceResponse> Send(TimeSpan? timeout = null, CancellationToken token = default)
         {
             var asyncReply = gatewayClient.DeployResourceAsync(request, deadline: timeout?.FromUtcNow(), cancellationToken: token);


### PR DESCRIPTION
Updates `DeployResourceCommand` to support TenantId.

This is one of two interfaces I would like to introduce for TenantId.

This begins the work to update the various builders to support multi-tenancy in [591](https://github.com/camunda-community-hub/zeebe-client-csharp/issues/591)


Splitting out into smaller PR's as requested by author.