### PR TITLE
ActivateJobsCommand updated to set tenantIds.

### DIFF
--- a/Client.UnitTests/ActivateJobTest.cs
+++ b/Client.UnitTests/ActivateJobTest.cs
@@ -183,12 +183,12 @@ namespace Zeebe.Client
 
             // when
             var response = await ZeebeClient.NewActivateJobsCommand()
-                .AddTenantIds(tenantIds)
                 .JobType("foo")
                 .MaxJobsToActivate(1)
                 .Timeout(TimeSpan.FromSeconds(10))
                 .WorkerName("jobWorker")
                 .PollingTimeout(TimeSpan.FromSeconds(5))
+                .TenantIds(tenantIds)
                 .Send();
 
             // then

--- a/Client/Api/Commands/IActivateJobsCommandStep1.cs
+++ b/Client/Api/Commands/IActivateJobsCommandStep1.cs
@@ -18,7 +18,7 @@ using Zeebe.Client.Api.Responses;
 
 namespace Zeebe.Client.Api.Commands
 {
-    public interface IActivateJobsCommandStep1
+    public interface IActivateJobsCommandStep1 : ITenantIdsCommandStep<IActivateJobsCommandStep1>
     {
         /// <summary>
         /// Set the type of jobs to work on.
@@ -28,7 +28,7 @@ namespace Zeebe.Client.Api.Commands
         IActivateJobsCommandStep2 JobType(string jobType);
     }
 
-    public interface IActivateJobsCommandStep2
+    public interface IActivateJobsCommandStep2 
     {
         /// <summary>
         /// Set the maximum of jobs to activate. If less jobs are available for activation the

--- a/Client/Api/Commands/IActivateJobsCommandStep1.cs
+++ b/Client/Api/Commands/IActivateJobsCommandStep1.cs
@@ -18,7 +18,7 @@ using Zeebe.Client.Api.Responses;
 
 namespace Zeebe.Client.Api.Commands
 {
-    public interface IActivateJobsCommandStep1 : ITenantIdsCommandStep<IActivateJobsCommandStep1>
+    public interface IActivateJobsCommandStep1
     {
         /// <summary>
         /// Set the type of jobs to work on.
@@ -39,7 +39,7 @@ namespace Zeebe.Client.Api.Commands
         IActivateJobsCommandStep3 MaxJobsToActivate(int maxJobsToActivate);
     }
 
-    public interface IActivateJobsCommandStep3 : IFinalCommandWithRetryStep<IActivateJobsResponse>
+    public interface IActivateJobsCommandStep3 : ITenantIdsCommandStep<IActivateJobsCommandStep3>, IFinalCommandWithRetryStep<IActivateJobsResponse>
     {
         /// <summary>
         /// Set the time for how long a job is exclusively assigned for this subscription.

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Zeebe.Client.Api.Commands
+{
+    public interface ITenantIdsCommandStep<out T>
+    {
+        /// <summary>
+        /// Set a lit of tenantIds to associate to this resource.
+        /// </summary>
+        /// <param name="tenantIds">the tenant to associate to this resource.</param>
+        /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
+        ///     to the broker.</returns>
+        T AddTenantIds(IList<string> tenantIds);
+
+        /// <summary>
+        /// Set a list of tenantIds to associate to this resource.
+        /// </summary>
+        /// <param name="tenantIds">the tenant to associate to this resource.</param>
+        /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
+        ///     to the broker.</returns>
+        T AddTenantIds(params string[] tenantIds);
+    }
+}

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -21,7 +21,7 @@ namespace Zeebe.Client.Api.Commands
         /// 
         /// This can be useful when requesting jobs for multiple tenants at once. Each of the activated 
         /// jobs will be owned by the tenant that owns the corresponding process instance.
-        /// <param name="tenantIds">the tenant to associate to this resource.</param>
+        /// <param name="tenantIds">the identifiers of the tenants to specify for this command, e.g. ["ACME", "OTHER"]</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
         ///     to the broker.</returns>
         T TenantIds(params string[] tenantIds);

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -10,7 +10,7 @@ namespace Zeebe.Client.Api.Commands
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
         ///     to the broker.</returns>
-        T AddTenantIds(IList<string> tenantIds);
+        T TenantIds(IList<string> tenantIds);
 
         /// <summary>
         /// Set a list of tenantIds to associate to this resource.
@@ -18,6 +18,6 @@ namespace Zeebe.Client.Api.Commands
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
         ///     to the broker.</returns>
-        T AddTenantIds(params string[] tenantIds);
+        T TenantIds(params string[] tenantIds);
     }
 }

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -5,7 +5,7 @@ namespace Zeebe.Client.Api.Commands
     public interface ITenantIdsCommandStep<out T>
     {
         /// <summary>
-        /// Set a list of tenantIds to associate with this resource.
+        /// Specifies the tenants that may own any entities (e.g. process definition, process instances, etc.) resulting from this command.
         /// </summary>
         /// 
         /// This can be useful when requesting jobs for multiple tenants at once. Each of the activated 

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -10,7 +10,7 @@ namespace Zeebe.Client.Api.Commands
         /// 
         /// This can be useful when requesting jobs for multiple tenants at once. Each of the activated 
         /// jobs will be owned by the tenant that owns the corresponding process instance.
-        /// <param name="tenantIds">the tenant to associate to this resource.</param>
+        /// <param name="tenantIds">the identifiers of the tenants to specify for this command, e.g. ["ACME", "OTHER"]</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
         ///     to the broker.</returns>
         T TenantIds(IList<string> tenantIds);

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -16,7 +16,7 @@ namespace Zeebe.Client.Api.Commands
         T TenantIds(IList<string> tenantIds);
 
         /// <summary>
-        /// Set a list of tenantIds to associate with this resource.
+        /// Specifies the tenants that may own any entities (e.g. process definition, process instances, etc.) resulting from this command.
         /// </summary>
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -5,7 +5,7 @@ namespace Zeebe.Client.Api.Commands
     public interface ITenantIdsCommandStep<out T>
     {
         /// <summary>
-        /// Set a lit of tenantIds to associate to this resource.
+        /// Set a list of tenantIds to associate with this resource.
         /// </summary>
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
@@ -13,7 +13,7 @@ namespace Zeebe.Client.Api.Commands
         T TenantIds(IList<string> tenantIds);
 
         /// <summary>
-        /// Set a list of tenantIds to associate to this resource.
+        /// Set a list of tenantIds to associate with this resource.
         /// </summary>
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -7,6 +7,9 @@ namespace Zeebe.Client.Api.Commands
         /// <summary>
         /// Set a list of tenantIds to associate with this resource.
         /// </summary>
+        /// 
+        /// This can be useful when requesting jobs for multiple tenants at once. Each of the activated 
+        /// jobs will be owned by the tenant that owns the corresponding process instance.
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
         ///     to the broker.</returns>

--- a/Client/Api/Commands/ITenantIdsCommandStep.cs
+++ b/Client/Api/Commands/ITenantIdsCommandStep.cs
@@ -18,6 +18,9 @@ namespace Zeebe.Client.Api.Commands
         /// <summary>
         /// Specifies the tenants that may own any entities (e.g. process definition, process instances, etc.) resulting from this command.
         /// </summary>
+        /// 
+        /// This can be useful when requesting jobs for multiple tenants at once. Each of the activated 
+        /// jobs will be owned by the tenant that owns the corresponding process instance.
         /// <param name="tenantIds">the tenant to associate to this resource.</param>
         /// <returns>The builder for this command.  Call <see cref="IFinalCommandStep{T}.Send"/> to complete the command and send it
         ///     to the broker.</returns>

--- a/Client/Impl/Commands/ActivateJobsCommand.cs
+++ b/Client/Impl/Commands/ActivateJobsCommand.cs
@@ -29,6 +29,20 @@ namespace Zeebe.Client.Impl.Commands
             return this;
         }
 
+        public IActivateJobsCommandStep1 AddTenantIds(IList<string> tenantIds)
+        {
+            Request.TenantIds.AddRange(tenantIds);
+
+            return this;
+        }
+
+        public IActivateJobsCommandStep1 AddTenantIds(params string[] tenantIds)
+        {
+            Request.TenantIds.AddRange(tenantIds);
+
+            return this;
+         }
+
         public IActivateJobsCommandStep3 MaxJobsToActivate(int maxJobsToActivate)
         {
             Request.MaxJobsToActivate = maxJobsToActivate;

--- a/Client/Impl/Commands/ActivateJobsCommand.cs
+++ b/Client/Impl/Commands/ActivateJobsCommand.cs
@@ -29,20 +29,6 @@ namespace Zeebe.Client.Impl.Commands
             return this;
         }
 
-        public IActivateJobsCommandStep1 AddTenantIds(IList<string> tenantIds)
-        {
-            Request.TenantIds.AddRange(tenantIds);
-
-            return this;
-        }
-
-        public IActivateJobsCommandStep1 AddTenantIds(params string[] tenantIds)
-        {
-            Request.TenantIds.AddRange(tenantIds);
-
-            return this;
-         }
-
         public IActivateJobsCommandStep3 MaxJobsToActivate(int maxJobsToActivate)
         {
             Request.MaxJobsToActivate = maxJobsToActivate;
@@ -76,6 +62,20 @@ namespace Zeebe.Client.Impl.Commands
         public IActivateJobsCommandStep3 WorkerName(string workerName)
         {
             Request.Worker = workerName;
+            return this;
+        }
+
+        public IActivateJobsCommandStep3 TenantIds(IList<string> tenantIds)
+        {
+            Request.TenantIds.AddRange(tenantIds);
+
+            return this;
+        }
+
+        public IActivateJobsCommandStep3 TenantIds(params string[] tenantIds)
+        {
+            Request.TenantIds.AddRange(tenantIds);
+
             return this;
         }
 


### PR DESCRIPTION
Updates `ActivateJobsCommand` to support TenantIds.

This is the second interface I would like to introduce for TenantIds.

This continues the work to update the various builders to support multi-tenancy in [591](https://github.com/camunda-community-hub/zeebe-client-csharp/issues/591)