### PR TITLE
feat: opportunity to realize graceful stopping IJobWorker instances

### DIFF
--- a/Client/Api/Worker/IJobWorker.cs
+++ b/Client/Api/Worker/IJobWorker.cs
@@ -28,5 +28,7 @@ namespace Zeebe.Client.Api.Worker
 
         /// <returns>true if this registration is not open and is not in the process of opening or closing</returns>
         bool IsClosed();
+
+        void StopPooling();
     }
 }

--- a/Client/Impl/Worker/JobWorker.cs
+++ b/Client/Impl/Worker/JobWorker.cs
@@ -87,6 +87,11 @@ namespace Zeebe.Client.Impl.Worker
             return !isRunning;
         }
 
+        public void StopPooling()
+        {
+            source.Cancel();
+        }
+
         /// <summary>
         /// Opens the configured JobWorker to activate jobs in the given poll interval
         /// and handle with the given handler.


### PR DESCRIPTION
Problem:
1) Under heavy load and a long time of the worker (4..30 sec), when the service ends, the following situation occurs: the worker has already successfully completed its work and begin to report zeebe about it, but zeebeClient has already been disposed.
System.ObjectDisposedException: Cannot access a disposed object.\nObject name: 'ZeebeClient was already disposed.'.\n
at AsyncUnaryCall<CompleteJobResponse> GatewayProtocol.ClosedGatewayClient.CompleteJobAsync(CompleteJobRequest request, Metadata headers, DateTime? deadline, CancellationToken cancellationToken)\n
at async Task<ICompleteJobResponse> Zeebe.Client.Impl.Commands.CompleteJobCommand.Send(TimeSpan? timeout, CancellationToken token) x 2\n

Really, the worker's task has already been done, but zeebe thinks that it is not correct and after a few time transfers it to another worker. There will be problems:
- if the worker’s task is not idempotent;
- time is wasted to transfers it to another worker, zeebe processes take longer to complete;
- more errors in logs that need spend time to be analyzed.

2) When the service shuts down, the current worker handlers are terminated, zeebe will wait for a timeout before transferring the task to other pods. Waste of time.

If it is possible to give a few seconds for the worker to finish the current work and report it to zeebe, there will be fewer time delays required to transfer tasks to other pods.

To implement such a strategy with zeebe-client, it is necessary possibility to stop pushing new tasks, while it must be able to report of complete on current ones; zeebeClient should not be disposed of before reporting.

A simplified implementation example is here
https://github.com/dimasm61/zeebe-client-csharp/tree/feat2_example/Client.GracefulStopping.Example