### PR TITLE
Add ModifyProcessInstance to client

### DIFF
--- a/Client.UnitTests/Client.UnitTests.csproj
+++ b/Client.UnitTests/Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>Zeebe.Client</RootNamespace>
   </PropertyGroup>
 

--- a/Client.UnitTests/GatewayTestService.cs
+++ b/Client.UnitTests/GatewayTestService.cs
@@ -62,6 +62,7 @@ namespace Zeebe.Client
             typedRequestHandler.Add(typeof(ResolveIncidentRequest), request => new ResolveIncidentResponse());
             typedRequestHandler.Add(typeof(CreateProcessInstanceWithResultRequest), request => new CreateProcessInstanceWithResultResponse());
             typedRequestHandler.Add(typeof(EvaluateDecisionRequest), request => new EvaluateDecisionResponse());
+            typedRequestHandler.Add(typeof(ModifyProcessInstanceRequest), request => new ModifyProcessInstanceResponse());
 
             foreach (var pair in typedRequestHandler)
             {
@@ -148,6 +149,11 @@ namespace Zeebe.Client
         public override Task<EvaluateDecisionResponse> EvaluateDecision(EvaluateDecisionRequest request, ServerCallContext context)
         {
             return Task.FromResult((EvaluateDecisionResponse)HandleRequest(request, context));
+        }
+
+        public override Task<ModifyProcessInstanceResponse> ModifyProcessInstance(ModifyProcessInstanceRequest request, ServerCallContext context)
+        {
+            return Task.FromResult((ModifyProcessInstanceResponse)HandleRequest(request, context));
         }
 
         public delegate void ConsumeMetadata(Metadata metadata);

--- a/Client.UnitTests/ModifyProcessInstanceTest.cs
+++ b/Client.UnitTests/ModifyProcessInstanceTest.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading.Tasks;
+using GatewayProtocol;
+using NUnit.Framework;
+
+namespace Zeebe.Client;
+
+[TestFixture]
+public class ModifyProcessInstanceTest : BaseZeebeTest
+{
+    [Test]
+    public async Task ShouldSendRequestAsExpected()
+    {
+        // given
+        var expectedRequest = new ModifyProcessInstanceRequest
+        {
+            ActivateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.ActivateInstruction
+                {
+                    ElementId = "test"
+                }
+            },
+            TerminateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.TerminateInstruction()
+            }
+        };
+
+        // when
+        await ZeebeClient.NewModifyProcessInstanceCommand(processInstanceKey: 0)
+            .AddInstructionToActivate(elementId: "test", ancestorElementInstanceKey: 0)
+            .AddInstructionToTerminate(elementInstanceKey: 0)
+            .Send();
+
+        // then
+        var request = TestService.Requests[typeof(ModifyProcessInstanceRequest)][0];
+        Assert.AreEqual(expectedRequest, request);
+    }
+
+    [Test]
+    public async Task ShouldReceiveResponseAsExpected()
+    {
+        // when
+        var modifyProcessInstanceResponse = await ZeebeClient.NewModifyProcessInstanceCommand(0)
+            .Send();
+
+        // then
+        Assert.IsNotNull(modifyProcessInstanceResponse);
+    }
+}

--- a/Client.UnitTests/ModifyProcessInstanceTest.cs
+++ b/Client.UnitTests/ModifyProcessInstanceTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using GatewayProtocol;
 using NUnit.Framework;
 
@@ -7,34 +9,174 @@ namespace Zeebe.Client;
 [TestFixture]
 public class ModifyProcessInstanceTest : BaseZeebeTest
 {
+    private readonly long testProcessInstanceKey = 1234567890;
+    private readonly long testAncestorElementInstanceKey = 2345678900;
+    private readonly long testElementInstanceKey = 3456789000;
+    private readonly string testElementId = "element1";
+    private readonly string testVariables = "variable1";
+    private readonly string testScopeId = "scope1";
+
     [Test]
-    public async Task ShouldSendRequestAsExpected()
+    public async Task ShouldSendRequestAsExpectedWithElementIdOnly()
     {
         // given
         var expectedRequest = new ModifyProcessInstanceRequest
         {
+            ProcessInstanceKey = testProcessInstanceKey,
             ActivateInstructions =
             {
                 new ModifyProcessInstanceRequest.Types.ActivateInstruction
                 {
-                    ElementId = "test"
+                    ElementId = testElementId,
+                    AncestorElementInstanceKey = 0
                 }
             },
             TerminateInstructions =
             {
                 new ModifyProcessInstanceRequest.Types.TerminateInstruction()
+                {
+                    ElementInstanceKey = testElementInstanceKey
+                }
             }
         };
 
         // when
-        await ZeebeClient.NewModifyProcessInstanceCommand(processInstanceKey: 0)
-            .AddInstructionToActivate(elementId: "test", ancestorElementInstanceKey: 0)
-            .AddInstructionToTerminate(elementInstanceKey: 0)
+        await ZeebeClient.NewModifyProcessInstanceCommand(processInstanceKey: testProcessInstanceKey)
+            .AddInstructionToActivate(elementId: testElementId)
+            .AddInstructionToTerminate(elementInstanceKey: testElementInstanceKey)
             .Send();
 
         // then
         var request = TestService.Requests[typeof(ModifyProcessInstanceRequest)][0];
-        Assert.AreEqual(expectedRequest, request);
+        var typedRequest = request as ModifyProcessInstanceRequest;
+        Assert.NotNull(typedRequest);
+        Assert.AreEqual(expectedRequest, typedRequest);
+    }
+
+    [Test]
+    public async Task ShouldSendRequestAsExpectedWithElementIdAndAncestorElementInstanceKey()
+    {
+        // given
+        var expectedRequest = new ModifyProcessInstanceRequest
+        {
+            ProcessInstanceKey = testProcessInstanceKey,
+            ActivateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.ActivateInstruction
+                {
+                    ElementId = testElementId,
+                    AncestorElementInstanceKey = testAncestorElementInstanceKey
+                }
+            },
+            TerminateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.TerminateInstruction()
+                {
+                    ElementInstanceKey = testElementInstanceKey
+                }
+            }
+        };
+
+        // when
+        await ZeebeClient.NewModifyProcessInstanceCommand(processInstanceKey: testProcessInstanceKey)
+            .AddInstructionToActivate(elementId: testElementId, ancestorElementInstanceKey: testAncestorElementInstanceKey)
+            .AddInstructionToTerminate(elementInstanceKey: testElementInstanceKey)
+            .Send();
+
+        // then
+        var request = TestService.Requests[typeof(ModifyProcessInstanceRequest)][0];
+        var typedRequest = request as ModifyProcessInstanceRequest;
+        Assert.NotNull(typedRequest);
+        Assert.AreEqual(expectedRequest, typedRequest);
+    }
+
+    [Test]
+    public async Task ShouldSendRequestAsExpectedWithElementIdAndVariableInstructions()
+    {
+        // given
+        var variableInstructions = new List<ModifyProcessInstanceRequest.Types.VariableInstruction>
+        {
+            new () { Variables = testVariables, ScopeId = testScopeId }
+        };
+
+        var expectedRequest = new ModifyProcessInstanceRequest
+        {
+            ProcessInstanceKey = testProcessInstanceKey,
+            ActivateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.ActivateInstruction
+                {
+                    ElementId = testElementId,
+                    AncestorElementInstanceKey = 0,
+                    VariableInstructions = { variableInstructions }
+                }
+            },
+            TerminateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.TerminateInstruction()
+                {
+                    ElementInstanceKey = testElementInstanceKey
+                }
+            }
+        };
+
+        // when
+        await ZeebeClient.NewModifyProcessInstanceCommand(processInstanceKey: testProcessInstanceKey)
+            .AddInstructionToActivate(elementId: testElementId, variableInstructions: variableInstructions)
+            .AddInstructionToTerminate(elementInstanceKey: testElementInstanceKey)
+            .Send();
+
+        // then
+        var request = TestService.Requests[typeof(ModifyProcessInstanceRequest)][0];
+        var typedRequest = request as ModifyProcessInstanceRequest;
+        Assert.NotNull(typedRequest);
+        Assert.AreEqual(expectedRequest, typedRequest);
+    }
+
+    [Test]
+    public async Task ShouldSendRequestAsExpectedWithElementIdAndAncestorElementInstanceKeyAndVariableInstructions()
+    {
+        // given
+        var variableInstructions = new List<ModifyProcessInstanceRequest.Types.VariableInstruction>
+        {
+            new () { Variables = testVariables, ScopeId = testScopeId }
+        };
+
+        var expectedRequest = new ModifyProcessInstanceRequest
+        {
+            ProcessInstanceKey = testProcessInstanceKey,
+            ActivateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.ActivateInstruction
+                {
+                    ElementId = testElementId,
+                    AncestorElementInstanceKey = testAncestorElementInstanceKey,
+                    VariableInstructions = { variableInstructions }
+                }
+            },
+            TerminateInstructions =
+            {
+                new ModifyProcessInstanceRequest.Types.TerminateInstruction()
+                {
+                     ElementInstanceKey = testElementInstanceKey
+                }
+            }
+        };
+
+        // when
+        await ZeebeClient.NewModifyProcessInstanceCommand(processInstanceKey: testProcessInstanceKey)
+            .AddInstructionToActivate(
+                elementId: testElementId,
+                ancestorElementInstanceKey: testAncestorElementInstanceKey,
+                variableInstructions: variableInstructions)
+            .AddInstructionToTerminate(elementInstanceKey: testElementInstanceKey)
+            .Send();
+
+        // then
+        var request = TestService.Requests[typeof(ModifyProcessInstanceRequest)][0];
+        var typedRequest = request as ModifyProcessInstanceRequest;
+        Assert.NotNull(typedRequest);
+        Assert.AreEqual(expectedRequest, typedRequest);
     }
 
     [Test]

--- a/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
+++ b/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
@@ -15,7 +15,7 @@ public interface IModifyProcessInstanceCommandStep1
     /// </summary>
     /// <param name="elementId">The id of the element to activate.</param>
     /// <returns>The builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 ActivateElement(string elementId);
+    IModifyProcessInstanceCommandStep3 ActivateElement(string elementId);
 
     /// <summary>
     /// Create an activate Instruction
@@ -25,7 +25,7 @@ public interface IModifyProcessInstanceCommandStep1
     /// <param name="elementId">The id of the element to activate.</param>
     /// <param name="ancestorElementInstanceKey">The element instance key in which the element will be created.</param>
     /// <returns>The builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 ActivateElement(string elementId, long ancestorElementInstanceKey);
+    IModifyProcessInstanceCommandStep3 ActivateElement(string elementId, long ancestorElementInstanceKey);
 
 
     /// <summary>

--- a/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
+++ b/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
@@ -12,8 +12,14 @@ public interface IModifyProcessInstanceCommandStep1 :
     /// </summary>
     /// <param name="elementInstanceKey">Element instance key for single terminate instruction.</param>
     /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToTerminate(
-        long elementInstanceKey);
+    IModifyProcessInstanceCommandStep1 AddInstructionToTerminate(long elementInstanceKey);
+
+    /// <summary>
+    /// Set the collection of instructions to activate at defined process instance.
+    /// </summary>
+    /// <param name="elementId">Element id for single instruction to activate.</param>
+    /// <returns>the builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId);
 
     /// <summary>
     /// Set the collection of instructions to activate at defined process instance.
@@ -21,5 +27,26 @@ public interface IModifyProcessInstanceCommandStep1 :
     /// <param name="elementId">Element id for single instruction to activate.</param>
     /// <param name="ancestorElementInstanceKey">Element key of ancestor to define scope to activate instruction.</param>
     /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId, long ancestorElementInstanceKey = 0);
+    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId, long ancestorElementInstanceKey);
+
+    /// <summary>
+    /// Set the collection of instructions to activate at defined process instance.
+    /// </summary>
+    /// <param name="elementId">Element id for single instruction to activate.</param>
+    /// <param name="variableInstructions">Instructions describing which variables should be created.</param>
+    /// <returns>the builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
+        string elementId, IEnumerable<ModifyProcessInstanceRequest.Types.VariableInstruction> variableInstructions);
+
+    /// <summary>
+    /// Set the collection of instructions to activate at defined process instance.
+    /// </summary>
+    /// <param name="elementId">Element id for single instruction to activate.</param>
+    /// <param name="ancestorElementInstanceKey">Element key of ancestor to define scope to activate instruction.</param>
+    /// <param name="variableInstructions">Instructions describing which variables should be created.</param>
+    /// <returns>the builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
+        string elementId,
+        long ancestorElementInstanceKey,
+        IEnumerable<ModifyProcessInstanceRequest.Types.VariableInstruction> variableInstructions);
 }

--- a/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
+++ b/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
@@ -1,52 +1,75 @@
-﻿using System.Collections.Generic;
-using GatewayProtocol;
-using Zeebe.Client.Api.Responses;
+﻿using Zeebe.Client.Api.Responses;
 
 namespace Zeebe.Client.Api.Commands;
 
-public interface IModifyProcessInstanceCommandStep1 :
+/// <summary>
+/// Command to modify a process instance.
+/// </summary>
+public interface IModifyProcessInstanceCommandStep1
+{
+    /// <summary>
+    /// Create an activate Instruction
+    /// for the given element id. The element will be created within an existing element instance of
+    /// the flow scope. When activating an element inside a multi-instance element the element instance
+    /// key of the ancestor must be defined. For this use <see cref="ActivateElement(string, long)"/>.
+    /// </summary>
+    /// <param name="elementId">The id of the element to activate.</param>
+    /// <returns>The builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 ActivateElement(string elementId);
+
+    /// <summary>
+    /// Create an activate Instruction
+    /// for the given element id. The element will be created within the scope that is passed. This
+    /// scope must be an ancestor of the element that's getting activated.
+    /// </summary>
+    /// <param name="elementId">The id of the element to activate.</param>
+    /// <param name="ancestorElementInstanceKey">The element instance key in which the element will be created.</param>
+    /// <returns>The builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 ActivateElement(string elementId, long ancestorElementInstanceKey);
+
+
+    /// <summary>
+    /// Create a terminate instruction for the given element id.
+    /// </summary>
+    /// <param name="elementInstanceKey">The element instance key of the element to terminate.</param>
+    /// <returns>the builder for this command.</returns>
+    IModifyProcessInstanceCommandStep2 TerminateElement(long elementInstanceKey);
+}
+
+/// <summary>
+/// Second command step, to optional add more instructions to activate or terminate.
+/// </summary>
+public interface IModifyProcessInstanceCommandStep2 :
     IFinalCommandWithRetryStep<IModifyProcessInstanceResponse>
 {
     /// <summary>
-    /// Set the collection of instructions to terminate at defined process instance.
+    /// Acts as a boundary between the different activate and terminate instructions. Use this if you
+    /// want to activate or terminate another element.
+    /// Otherwise, use <see cref="IFinalCommandWithRetryStep{T}.SendWithRetry"/> to send the command.
     /// </summary>
-    /// <param name="elementInstanceKey">Element instance key for single terminate instruction.</param>
-    /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToTerminate(long elementInstanceKey);
+    /// <returns>The builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 And();
+}
+
+/// <summary>
+/// Third command step, to optionally add variables to the element which should be activated.
+/// </summary>
+public interface IModifyProcessInstanceCommandStep3 : IModifyProcessInstanceCommandStep2
+{
+    /// <summary>
+    ///  Create a variable instruction for the element that's getting activated.
+    ///  These variables will be created in the global scope of the process instance.
+    /// </summary>
+    /// <param name="variables">The variables JSON document as String.</param>
+    /// <returns>The builder for this command.</returns>
+    IModifyProcessInstanceCommandStep3 WithVariables(string variables);
 
     /// <summary>
-    /// Set the collection of instructions to activate at defined process instance.
+    ///  Create a variable instruction for the element that's getting activated.
+    ///  These variables will be created in the scope of the passed element.
     /// </summary>
-    /// <param name="elementId">Element id for single instruction to activate.</param>
-    /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId);
-
-    /// <summary>
-    /// Set the collection of instructions to activate at defined process instance.
-    /// </summary>
-    /// <param name="elementId">Element id for single instruction to activate.</param>
-    /// <param name="ancestorElementInstanceKey">Element key of ancestor to define scope to activate instruction.</param>
-    /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId, long ancestorElementInstanceKey);
-
-    /// <summary>
-    /// Set the collection of instructions to activate at defined process instance.
-    /// </summary>
-    /// <param name="elementId">Element id for single instruction to activate.</param>
-    /// <param name="variableInstructions">Instructions describing which variables should be created.</param>
-    /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
-        string elementId, IEnumerable<ModifyProcessInstanceRequest.Types.VariableInstruction> variableInstructions);
-
-    /// <summary>
-    /// Set the collection of instructions to activate at defined process instance.
-    /// </summary>
-    /// <param name="elementId">Element id for single instruction to activate.</param>
-    /// <param name="ancestorElementInstanceKey">Element key of ancestor to define scope to activate instruction.</param>
-    /// <param name="variableInstructions">Instructions describing which variables should be created.</param>
-    /// <returns>the builder for this command.</returns>
-    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
-        string elementId,
-        long ancestorElementInstanceKey,
-        IEnumerable<ModifyProcessInstanceRequest.Types.VariableInstruction> variableInstructions);
+    /// <param name="variables">The variables JSON document as String.</param>
+    /// <param name="scopeId">The id of the element in which scope the variables should be created.</param>
+    /// <returns>The builder for this command.</returns>
+    IModifyProcessInstanceCommandStep3 WithVariables(string variables, string scopeId);
 }

--- a/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
+++ b/Client/Api/Commands/IModifyProcessInstanceCommandStep1.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using GatewayProtocol;
+using Zeebe.Client.Api.Responses;
+
+namespace Zeebe.Client.Api.Commands;
+
+public interface IModifyProcessInstanceCommandStep1 :
+    IFinalCommandWithRetryStep<IModifyProcessInstanceResponse>
+{
+    /// <summary>
+    /// Set the collection of instructions to terminate at defined process instance.
+    /// </summary>
+    /// <param name="elementInstanceKey">Element instance key for single terminate instruction.</param>
+    /// <returns>the builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 AddInstructionToTerminate(
+        long elementInstanceKey);
+
+    /// <summary>
+    /// Set the collection of instructions to activate at defined process instance.
+    /// </summary>
+    /// <param name="elementId">Element id for single instruction to activate.</param>
+    /// <param name="ancestorElementInstanceKey">Element key of ancestor to define scope to activate instruction.</param>
+    /// <returns>the builder for this command.</returns>
+    IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId, long ancestorElementInstanceKey = 0);
+}

--- a/Client/Api/Responses/IModifyProcessInstanceResponse.cs
+++ b/Client/Api/Responses/IModifyProcessInstanceResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Zeebe.Client.Api.Responses;
+
+/// <summary>
+/// Response on a process instance to modification.
+/// </summary>
+public interface IModifyProcessInstanceResponse
+{
+}

--- a/Client/IZeebeClient.cs
+++ b/Client/IZeebeClient.cs
@@ -246,6 +246,26 @@ namespace Zeebe.Client
         IPublishMessageCommandStep1 NewPublishMessageCommand();
 
         /// <summary>
+        /// Command to modify a process which can be correlated to a process instance.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// zeebeClient
+        ///  .NewModifyProcessInstanceCommand(processInstanceKey)
+        ///  .AddInstructionToActivate(long elementInstanceKey)
+        ///  .AddInstructionToTerminate(string elementId, long ancestorElementInstanceKey = 0)
+        ///  .Send();
+        /// </code>
+        /// </example>
+        /// <param name="processInstanceKey">
+        ///     processInstanceKey the key which identifies the corresponding process instance.
+        /// </param>
+        /// <returns>
+        ///     a builder for the command.
+        /// </returns>
+        IModifyProcessInstanceCommandStep1 NewModifyProcessInstanceCommand(long processInstanceKey);
+
+        /// <summary>
         /// Request the current cluster topology. Can be used to inspect which brokers are available at
         /// which endpoint and which broker is the leader of which partition.
         /// </summary>

--- a/Client/IZeebeClient.cs
+++ b/Client/IZeebeClient.cs
@@ -246,23 +246,25 @@ namespace Zeebe.Client
         IPublishMessageCommandStep1 NewPublishMessageCommand();
 
         /// <summary>
-        /// Command to modify a process which can be correlated to a process instance.
+        /// Command to modify a process instance.
         /// </summary>
         /// <example>
         /// <code>
         /// zeebeClient
-        ///  .NewModifyProcessInstanceCommand(processInstanceKey)
-        ///  .AddInstructionToActivate(long elementInstanceKey)
-        ///  .AddInstructionToTerminate(string elementId, long ancestorElementInstanceKey)
-        ///  .Send();
+        ///     .NewModifyProcessInstanceCommand(processInstanceKey)
+        ///     .ActivateElement("element1")
+        ///     .And()
+        ///     .ActivateElement("element2")
+        ///     .WithVariables(globalScopedVariables)
+        ///     .WithVariables(localScopedVariables, "element2")
+        ///     .And()
+        ///     .TerminateElement("element3")
+        ///     .SendWithRetry();
         /// </code>
         /// </example>
-        /// <param name="processInstanceKey">
-        ///     processInstanceKey the key which identifies the corresponding process instance.
+        /// <param name="processInstanceKey">The key which identifies the corresponding process instance.
         /// </param>
-        /// <returns>
-        ///     a builder for the command.
-        /// </returns>
+        /// <returns> a builder for the command.</returns>
         IModifyProcessInstanceCommandStep1 NewModifyProcessInstanceCommand(long processInstanceKey);
 
         /// <summary>

--- a/Client/IZeebeClient.cs
+++ b/Client/IZeebeClient.cs
@@ -253,7 +253,7 @@ namespace Zeebe.Client
         /// zeebeClient
         ///  .NewModifyProcessInstanceCommand(processInstanceKey)
         ///  .AddInstructionToActivate(long elementInstanceKey)
-        ///  .AddInstructionToTerminate(string elementId, long ancestorElementInstanceKey = 0)
+        ///  .AddInstructionToTerminate(string elementId, long ancestorElementInstanceKey)
         ///  .Send();
         /// </code>
         /// </example>

--- a/Client/Impl/Commands/ModifyProcessInstanceCommand.cs
+++ b/Client/Impl/Commands/ModifyProcessInstanceCommand.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GatewayProtocol;
+using Zeebe.Client.Api.Commands;
+using Zeebe.Client.Api.Misc;
+using Zeebe.Client.Api.Responses;
+
+using static GatewayProtocol.Gateway;
+
+namespace Zeebe.Client.Impl.Commands;
+
+internal class ModifyProcessInstanceCommand : IModifyProcessInstanceCommandStep1
+{
+    private readonly ModifyProcessInstanceRequest request;
+    private readonly GatewayClient client;
+    private readonly IAsyncRetryStrategy asyncRetryStrategy;
+
+    private readonly IList<ModifyProcessInstanceRequest.Types.TerminateInstruction> terminateInstructions;
+    private readonly IList<ModifyProcessInstanceRequest.Types.ActivateInstruction> activateInstructions;
+
+    public ModifyProcessInstanceCommand(GatewayClient client, IAsyncRetryStrategy asyncRetryStrategy, long processInstanceKey)
+    {
+        terminateInstructions = new List<ModifyProcessInstanceRequest.Types.TerminateInstruction>();
+        activateInstructions = new List<ModifyProcessInstanceRequest.Types.ActivateInstruction>();
+
+        this.asyncRetryStrategy = asyncRetryStrategy;
+        this.client = client;
+
+        request = new ModifyProcessInstanceRequest
+        {
+            ProcessInstanceKey = processInstanceKey
+        };
+    }
+
+    public IModifyProcessInstanceCommandStep1 AddInstructionToTerminate(long elementInstanceKey)
+    {
+        var terminateInstruction = new ModifyProcessInstanceRequest.Types.TerminateInstruction
+        {
+            ElementInstanceKey = elementInstanceKey
+        };
+
+        terminateInstructions.Add(terminateInstruction);
+        return this;
+    }
+
+    public IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
+        string elementId,
+        long ancestorElementInstanceKey = 0)
+    {
+        var activateInstruction = new ModifyProcessInstanceRequest.Types.ActivateInstruction
+        {
+            ElementId = elementId,
+            AncestorElementInstanceKey = ancestorElementInstanceKey
+        };
+
+        activateInstructions.Add(activateInstruction);
+        return this;
+    }
+
+    public async Task<IModifyProcessInstanceResponse> Send(TimeSpan? timeout = null, CancellationToken token = default)
+    {
+        request.TerminateInstructions.AddRange(terminateInstructions);
+        request.ActivateInstructions.AddRange(activateInstructions);
+
+        var asyncReply = client.ModifyProcessInstanceAsync(request, cancellationToken: token);
+        await asyncReply.ResponseAsync;
+        return new Responses.ModifyProcessInstanceResponse();
+    }
+
+    public async Task<IModifyProcessInstanceResponse> Send(CancellationToken cancellationToken)
+    {
+        return await Send(token: cancellationToken);
+    }
+
+    public async Task<IModifyProcessInstanceResponse> SendWithRetry(TimeSpan? timeout = null, CancellationToken token = default)
+    {
+        return await asyncRetryStrategy.DoWithRetry(() => Send(timeout, token));
+    }
+}

--- a/Client/Impl/Commands/ModifyProcessInstanceCommand.cs
+++ b/Client/Impl/Commands/ModifyProcessInstanceCommand.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GatewayProtocol;
+using Google.Protobuf.Collections;
 using Zeebe.Client.Api.Commands;
 using Zeebe.Client.Api.Misc;
 using Zeebe.Client.Api.Responses;
@@ -45,14 +47,57 @@ internal class ModifyProcessInstanceCommand : IModifyProcessInstanceCommandStep1
         return this;
     }
 
+    public IModifyProcessInstanceCommandStep1 AddInstructionToActivate(string elementId)
+    {
+        var activateInstruction = new ModifyProcessInstanceRequest.Types.ActivateInstruction
+        {
+            ElementId = elementId,
+            AncestorElementInstanceKey = 0
+        };
+
+        activateInstructions.Add(activateInstruction);
+        return this;
+    }
+
     public IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
         string elementId,
-        long ancestorElementInstanceKey = 0)
+        long ancestorElementInstanceKey)
     {
         var activateInstruction = new ModifyProcessInstanceRequest.Types.ActivateInstruction
         {
             ElementId = elementId,
             AncestorElementInstanceKey = ancestorElementInstanceKey
+        };
+
+        activateInstructions.Add(activateInstruction);
+        return this;
+    }
+
+    public IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
+        string elementId,
+        IEnumerable<ModifyProcessInstanceRequest.Types.VariableInstruction> variableInstructions)
+    {
+        var activateInstruction = new ModifyProcessInstanceRequest.Types.ActivateInstruction
+        {
+            ElementId = elementId,
+            AncestorElementInstanceKey = 0,
+            VariableInstructions = { variableInstructions }
+        };
+
+        activateInstructions.Add(activateInstruction);
+        return this;
+    }
+
+    public IModifyProcessInstanceCommandStep1 AddInstructionToActivate(
+        string elementId,
+        long ancestorElementInstanceKey,
+        IEnumerable<ModifyProcessInstanceRequest.Types.VariableInstruction> variableInstructions)
+    {
+        var activateInstruction = new ModifyProcessInstanceRequest.Types.ActivateInstruction
+        {
+            ElementId = elementId,
+            AncestorElementInstanceKey = ancestorElementInstanceKey,
+            VariableInstructions = { variableInstructions }
         };
 
         activateInstructions.Add(activateInstruction);

--- a/Client/Impl/Responses/ModifyProcessInstanceResponse.cs
+++ b/Client/Impl/Responses/ModifyProcessInstanceResponse.cs
@@ -1,0 +1,7 @@
+﻿using Zeebe.Client.Api.Responses;
+
+namespace Zeebe.Client.Impl.Responses;
+
+public class ModifyProcessInstanceResponse : IModifyProcessInstanceResponse
+{
+}

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -232,6 +232,11 @@ namespace Zeebe.Client
             return new PublishMessageCommand(gatewayClient, asyncRetryStrategy);
         }
 
+        public IModifyProcessInstanceCommandStep1 NewModifyProcessInstanceCommand(long processInstanceKey)
+        {
+            return new ModifyProcessInstanceCommand(gatewayClient, asyncRetryStrategy, processInstanceKey);
+        }
+
         public ITopologyRequestStep1 TopologyRequest() => new TopologyRequestCommand(gatewayClient, asyncRetryStrategy);
 
         public void Dispose()


### PR DESCRIPTION
_Based on https://github.com/camunda-community-hub/zeebe-client-csharp/pull/622_

I took the state from https://github.com/camunda-community-hub/zeebe-client-csharp/pull/622 and reworked it a bit to align with the Java client implementation, so examples can be reused and we have the same experience in the clients. See related interface in Java client https://github.com/camunda/zeebe/blob/main/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java

closes #622 
