### PR TITLE
fix(deployment): Added support for form deployment response

### DIFF
--- a/Client.UnitTests/Resources/demo-form.form
+++ b/Client.UnitTests/Resources/demo-form.form
@@ -1,0 +1,23 @@
+{
+  "components": [
+    {
+      "label": "Demo checkbox",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_0b67lfv",
+        "columns": null
+      },
+      "id": "Field_18jrp23",
+      "key": "demoCheckbox"
+    }
+  ],
+  "type": "default",
+  "id": "demoForm",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.4.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.19.0"
+  },
+  "schemaVersion": 14
+}

--- a/Client/Api/Responses/IDeployResourceResponse.cs
+++ b/Client/Api/Responses/IDeployResourceResponse.cs
@@ -15,5 +15,8 @@ namespace Zeebe.Client.Api.Responses
 
         /// <returns>the decision requirements which are deployed </returns>
         IList<IDecisionRequirementsMetadata> DecisionRequirements { get; }
+
+        /// <returns>the forms which are deployed</returns>
+        IList<IFormMetadata> Forms { get; }
     }
 }

--- a/Client/Api/Responses/IFormMetadata.cs
+++ b/Client/Api/Responses/IFormMetadata.cs
@@ -13,4 +13,7 @@ public interface IFormMetadata
 
     /// <returns>the name of the deployment resource which contains the form.</returns>
     string ResourceName { get; }
+
+    /// <returns>the tenant ID of the deployed form.</returns>
+    string TenantId { get; }
 }

--- a/Client/Api/Responses/IFormMetadata.cs
+++ b/Client/Api/Responses/IFormMetadata.cs
@@ -1,0 +1,16 @@
+namespace Zeebe.Client.Api.Responses;
+
+public interface IFormMetadata
+{
+    /// <returns>the form ID of the deployed form.</returns>
+    string FormId { get; }
+
+    /// <returns>the version of the deployed form.</returns>
+    int Version { get; }
+
+    /// <returns>the key of the deployed form.</returns>
+    long FormKey { get; }
+
+    /// <returns>the name of the deployment resource which contains the form.</returns>
+    string ResourceName { get; }
+}

--- a/Client/Impl/Responses/DeployResourceResponse.cs
+++ b/Client/Impl/Responses/DeployResourceResponse.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using GatewayProtocol;
 using Zeebe.Client.Api.Responses;
 
@@ -12,6 +11,7 @@ namespace Zeebe.Client.Impl.Responses
         public IList<IProcessMetadata> Processes { get; }
         public IList<IDecisionMetadata> Decisions { get; }
         public IList<IDecisionRequirementsMetadata> DecisionRequirements { get; }
+        public IList<IFormMetadata> Forms { get; }
 
         public DeployResourceResponse(GatewayProtocol.DeployResourceResponse response)
         {
@@ -19,6 +19,7 @@ namespace Zeebe.Client.Impl.Responses
             Processes = new List<IProcessMetadata>();
             Decisions = new List<IDecisionMetadata>();
             DecisionRequirements = new List<IDecisionRequirementsMetadata>();
+            Forms = new List<IFormMetadata>();
 
             foreach (var deployment in response.Deployments)
             {
@@ -32,6 +33,9 @@ namespace Zeebe.Client.Impl.Responses
                         break;
                     case Deployment.MetadataOneofCase.DecisionRequirements:
                         DecisionRequirements.Add(new DecisionRequirementsMetadata(deployment.DecisionRequirements));
+                        break;
+                    case Deployment.MetadataOneofCase.Form:
+                        Forms.Add(new FormMetadata(deployment.Form));
                         break;
                     default:
                         throw new NotImplementedException("Got deployment response for unexpected type: " +

--- a/Client/Impl/Responses/FormMetadata.cs
+++ b/Client/Impl/Responses/FormMetadata.cs
@@ -8,6 +8,7 @@ public class FormMetadata : IFormMetadata
     public int Version { get; }
     public long FormKey { get; }
     public string ResourceName { get; }
+    public string TenantId { get; }
 
     public FormMetadata(GatewayProtocol.FormMetadata metadata)
     {
@@ -15,5 +16,6 @@ public class FormMetadata : IFormMetadata
         Version = metadata.Version;
         FormKey = metadata.FormKey;
         ResourceName = metadata.ResourceName;
+        TenantId = metadata.TenantId;
     }
 }

--- a/Client/Impl/Responses/FormMetadata.cs
+++ b/Client/Impl/Responses/FormMetadata.cs
@@ -1,0 +1,19 @@
+using Zeebe.Client.Api.Responses;
+
+namespace Zeebe.Client.Impl.Responses;
+
+public class FormMetadata : IFormMetadata
+{
+    public string FormId { get; }
+    public int Version { get; }
+    public long FormKey { get; }
+    public string ResourceName { get; }
+
+    public FormMetadata(GatewayProtocol.FormMetadata metadata)
+    {
+        FormId = metadata.FormId;
+        Version = metadata.Version;
+        FormKey = metadata.FormKey;
+        ResourceName = metadata.ResourceName;
+    }
+}


### PR DESCRIPTION
This PR adds support for form deployment response and closes #648

I've tried to keep the implementation as similar as possible to the existing deployment response types. Let me know if there is anything else I should include in this PR.
