### PR TITLE
feat: add tenantId to both create process and publish message commands

### DIFF
--- a/Client/Api/Commands/ICreateProcessInstanceCommandStep1.cs
+++ b/Client/Api/Commands/ICreateProcessInstanceCommandStep1.cs
@@ -43,7 +43,7 @@ namespace Zeebe.Client.Api.Commands
         ICreateProcessInstanceCommandStep3 LatestVersion();
     }
 
-    public interface ICreateProcessInstanceCommandStep3 : IFinalCommandWithRetryStep<IProcessInstanceResponse>
+    public interface ICreateProcessInstanceCommandStep3 : IFinalCommandWithRetryStep<IProcessInstanceResponse>, ITenantIdCommandStep<ICreateProcessInstanceCommandStep3>
     {
         /// <summary>
         /// Set the initial variables of the process instance.

--- a/Client/Api/Commands/IPublishMessageCommandStep1.cs
+++ b/Client/Api/Commands/IPublishMessageCommandStep1.cs
@@ -41,7 +41,7 @@ namespace Zeebe.Client.Api.Commands
         IPublishMessageCommandStep3 CorrelationKey(string correlationKey);
     }
 
-    public interface IPublishMessageCommandStep3 : IFinalCommandWithRetryStep<IPublishMessageResponse>
+    public interface IPublishMessageCommandStep3 : IFinalCommandWithRetryStep<IPublishMessageResponse>, ITenantIdCommandStep<IPublishMessageCommandStep3>
     {
         /// <summary>
         /// Set the id of the message. The message is rejected if another message is already published

--- a/Client/Impl/Commands/CreateProcessInstanceCommand.cs
+++ b/Client/Impl/Commands/CreateProcessInstanceCommand.cs
@@ -58,6 +58,12 @@ namespace Zeebe.Client.Impl.Commands
             return this;
         }
 
+        public ICreateProcessInstanceCommandStep3 AddTenantId(string tenantId)
+        {
+            request.TenantId = tenantId;
+            return this;
+        }
+
         public ICreateProcessInstanceWithResultCommandStep1 WithResult()
         {
             return new CreateProcessInstanceCommandWithResult(client, asyncRetryStrategy, request);

--- a/Client/Impl/Commands/PublishMessageCommand.cs
+++ b/Client/Impl/Commands/PublishMessageCommand.cs
@@ -62,6 +62,12 @@ namespace Zeebe.Client.Impl.Commands
             return this;
         }
 
+        public IPublishMessageCommandStep3 AddTenantId(string tenantId)
+        {
+            request.TenantId = tenantId;
+            return this;
+        }
+
         public IPublishMessageCommandStep3 TimeToLive(TimeSpan timeToLive)
         {
             request.TimeToLive = (long)timeToLive.TotalMilliseconds;


### PR DESCRIPTION
Allows for the passing of tenantId in the request for creating a new process and publishing a message. Useful in a multitenancy environment

closes #
