### PR TITLE
add interceptors grpc

### DIFF
--- a/Client.UnitTests/ZeebeAuthTest.cs
+++ b/Client.UnitTests/ZeebeAuthTest.cs
@@ -107,7 +107,7 @@ public class ZeebeAuthTest
     class MyInterceptor : Interceptor { }
 
     [Test]
-    public async Task ShouldUseTransportEncryptionWithServerCer2t()
+    public async Task ShouldUseTransportEncryptionWithServerCertAndNewInterceptor()
     {
         // given
         var zeebeClient = ZeebeClient.Builder()

--- a/Client.UnitTests/ZeebeAuthTest.cs
+++ b/Client.UnitTests/ZeebeAuthTest.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GatewayProtocol;
 using Grpc.Core;
+using Grpc.Core.Interceptors;
 using Grpc.Core.Logging;
 using NUnit.Framework;
 using Zeebe.Client.Api.Builder;
@@ -90,6 +91,30 @@ public class ZeebeAuthTest
             .UseGatewayAddress("localhost:26505")
             .UseTransportEncryption(ServerCertPath)
             .AllowUntrustedCertificates()
+            .Build();
+
+        // when
+        var publishMessageResponse = await zeebeClient
+            .NewPublishMessageCommand()
+            .MessageName("messageName")
+            .CorrelationKey("p-1")
+            .Send();
+
+        // then
+        Assert.NotNull(publishMessageResponse);
+    }
+
+    class MyInterceptor : Interceptor { }
+
+    [Test]
+    public async Task ShouldUseTransportEncryptionWithServerCer2t()
+    {
+        // given
+        var zeebeClient = ZeebeClient.Builder()
+            .UseGatewayAddress("localhost:26505")
+            .UseTransportEncryption(ServerCertPath)
+            .AllowUntrustedCertificates()
+            .UseInterceptors(new MyInterceptor())
             .Build();
 
         // when

--- a/Client/Api/Builder/IZeebeClientBuilder.cs
+++ b/Client/Api/Builder/IZeebeClientBuilder.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.CompilerServices;
+using Grpc.Core.Interceptors;
 using Microsoft.Extensions.Logging;
 
 namespace Zeebe.Client.Api.Builder
@@ -50,6 +52,8 @@ namespace Zeebe.Client.Api.Builder
 
     public interface IZeebeSecureClientBuilder : IZeebeClientFinalBuildStep
     {
+        IZeebeSecureClientBuilder UseInterceptors(params Interceptor[] interceptors);
+
         /// <summary>
         /// DANGER: This allows untrusted certificates for the gRPC connection with Zeebe.
         ///

--- a/Client/IZeebeClient.cs
+++ b/Client/IZeebeClient.cs
@@ -12,6 +12,7 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+using Grpc.Core.Interceptors;
 using System;
 using Zeebe.Client.Api.Commands;
 using Zeebe.Client.Api.Worker;
@@ -306,5 +307,11 @@ namespace Zeebe.Client
         ///     the request where you must call <see cref="IFinalCommandStep{T}.Send"/>
         /// </returns>
         ITopologyRequestStep1 TopologyRequest();
+
+        /// <summary>
+        /// Add user intereceptors to channel grpc 
+        /// </summary>
+        /// <param name="interceptors">Interceptors</param>
+        void AddInterceptor(params Interceptor[] interceptors);
     }
 }

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -107,6 +107,8 @@ namespace Zeebe.Client
 
         public void AddInterceptor(params Interceptor[] interceptors)
         {
+            if (interceptors == null || !interceptors.Any()) return;
+
             List<Interceptor> list = new List<Interceptor>(interceptors)
             {
                 new UserAgentInterceptor()

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -105,6 +105,18 @@ namespace Zeebe.Client
                                                     DefaultWaitTimeProvider);
         }
 
+        public void AddInterceptor(params Interceptor[] interceptors)
+        {
+            List<Interceptor> list = new List<Interceptor>(interceptors)
+            {
+                new UserAgentInterceptor()
+            };
+
+            var callInvoker = channelToGateway.Intercept([.. list]);
+            gatewayClient = new Gateway.GatewayClient(callInvoker);
+        } 
+
+
         public async Task Connect()
         {
             await channelToGateway.ConnectAsync();


### PR DESCRIPTION
closes #
I think it might be necessary to use grpc interceptors for the channel and I have created a method to be able to add interceptors. It could be used for example to create an interceptor to send traces with Opentelemetry.