### PR TITLE
refactor: get rid of Grpc.core dependency into ZeebeClient

### DIFF
--- a/Client.UnitTests/Client.UnitTests.csproj
+++ b/Client.UnitTests/Client.UnitTests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="Grpc" version="2.46.6" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -38,7 +38,6 @@ This release is based on the Zeebe 8.5.6 release (https://github.com/zeebe-io/ze
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" version="3.28.2" />
-    <PackageReference Include="Grpc" version="2.46.6" />
     <PackageReference Include="Grpc.Auth" Version="2.66.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
     <PackageReference Include="Grpc.Tools" version="2.67.0">

--- a/Client/ZeebeClient.cs
+++ b/Client/ZeebeClient.cs
@@ -135,28 +135,9 @@ namespace Zeebe.Client
             }
         }
 
-        /// <summary>
-        /// Adds keepAlive options to the channel options.
-        /// </summary>
-        /// <param name="channelOptions">the current existing channel options.</param>
-        private void AddKeepAliveToChannelOptions(List<ChannelOption> channelOptions, TimeSpan? keepAlive)
-        {
-            // GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS
-            // This channel argument if set to 1 (0 : false; 1 : true), allows keepalive pings to be sent even if there are no calls in flight.
-            // channelOptions.Add(new ChannelOption("grpc.keepalive_permit_without_calls", "1"));
-            // this will increase load on the system and also increase used resources
-            // we should prefer idleTimeout setting
-            // https://stackoverflow.com/questions/57930529/grpc-connection-use-keepalive-or-idletimeout
-
-            // GRPC_ARG_KEEPALIVE_TIME_MS
-            // This channel argument controls the period (in milliseconds) after which a keepalive ping is sent on the transport.
-            var actualKeepAlive = keepAlive.GetValueOrDefault(DefaultKeepAlive);
-            channelOptions.Add(new ChannelOption("grpc.keepalive_time_ms", (int) actualKeepAlive.TotalMilliseconds));
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        ///////////////////////////// JOBS /////////////////////////////////////
-        ////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+    ///////////////////////////// JOBS /////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
 
         public IJobWorkerBuilderStep1 NewWorker()
         {


### PR DESCRIPTION
This 1st PR only moves the Grpc.Core dependency to tests. The client is clean after that. Note that Grpc.Core.Api is still part of the https://github.com/grpc/grpc-dotnet project.
