### PR TITLE
feat: Added optional start process at elementId

### DIFF
--- a/Client.UnitTests/CreateProcessInstanceWithResultTest.cs
+++ b/Client.UnitTests/CreateProcessInstanceWithResultTest.cs
@@ -112,6 +112,30 @@ namespace Zeebe.Client
         }
 
         [Test]
+        public async Task ShouldSendRequestWithStartInstructionAsExpected()
+        {
+            // given
+            var expectedRequest = new CreateProcessInstanceWithResultRequest
+            {
+                Request = new CreateProcessInstanceRequest
+                {
+                    StartInstructions = { new ProcessInstanceCreationStartInstruction { ElementId = "StartHere" } }
+                },
+                RequestTimeout = 20 * 1000
+            };
+
+            // when
+            await ZeebeClient.NewCreateProcessInstanceCommand()
+                .AddStartInstruction("StartHere")
+                .WithResult()
+                .Send();
+
+            // then
+            var request = TestService.Requests[typeof(CreateProcessInstanceWithResultRequest)][0];
+            Assert.AreEqual(expectedRequest, request);
+        }
+
+        [Test]
         public async Task ShouldSendRequestWithProcessDefinitionKeyAsExpected()
         {
             // given

--- a/Client/Api/Commands/ICreateProcessInstanceCommandStep1.cs
+++ b/Client/Api/Commands/ICreateProcessInstanceCommandStep1.cs
@@ -14,6 +14,13 @@ namespace Zeebe.Client.Api.Commands
         ICreateProcessInstanceCommandStep2 BpmnProcessId(string bpmnProcessId);
 
         /// <summary>
+        /// Sets optional start instruction when process instance is created
+        /// </summary>
+        /// <param name="elementId">the BPMN element id from the process</param>
+        /// <returns>the builder for this command</returns>
+        ICreateProcessInstanceCommandStep3 AddStartInstruction(string elementId);
+
+        /// <summary>
         /// Set the key of the process to create an instance of. The key is assigned by the broker while
         /// deploying the process. It can be picked from the deployment or process event.
         /// </summary>

--- a/Client/Impl/Commands/CreateProcessInstanceCommand.cs
+++ b/Client/Impl/Commands/CreateProcessInstanceCommand.cs
@@ -54,6 +54,12 @@ public class CreateProcessInstanceCommand(Gateway.GatewayClient client, IAsyncRe
         return this;
     }
 
+    public ICreateProcessInstanceCommandStep3 AddStartInstruction(string elementId)
+    {
+        request.StartInstructions.Add(new ProcessInstanceCreationStartInstruction { ElementId = elementId });
+        return this;
+    }
+
     public ICreateProcessInstanceWithResultCommandStep1 WithResult()
     {
         return new CreateProcessInstanceCommandWithResult(client, asyncRetryStrategy, request);


### PR DESCRIPTION
closes #581 

## Background

We have maintained a separate fork of this library that has the ability to start a process at a specific elementId. To avoid keeping this fork up to date manually, we'd like to share the functionality as it seems more people are missing it and at the same time bring the functionality into the main line of the client.
