### PR TITLE
CamundaCloudTokenProvider - Allow disabling of file system credentials cache persistence and add tolerance for token expiration

### DIFF
--- a/Client.UnitTests/Impl/Builder/CamundaCloudTokenProviderTest.cs
+++ b/Client.UnitTests/Impl/Builder/CamundaCloudTokenProviderTest.cs
@@ -123,4 +123,26 @@ public class CamundaCloudTokenProviderTest
         // then
         Assert.AreEqual(2, MessageHandlerStub.RequestCount);
     }
+
+    [Test]
+    public void ShouldThrowArgumentExceptionForInvalidAccessTokenDueDateTolerance()
+    {
+        // given
+        var builder = new CamundaCloudTokenProviderBuilder();
+
+        // then
+        Assert.Throws<ArgumentException>(() => builder
+            .UseAccessTokenDueDateTolerance(TimeSpan.FromSeconds(-2)));
+    }
+
+    [Test]
+    public void ShouldNotThrowArgumentExceptionForValidAccessTokenDueDateTolerance()
+    {
+        // given
+        var builder = new CamundaCloudTokenProviderBuilder();
+
+        // then
+        Assert.DoesNotThrow(() => builder
+            .UseAccessTokenDueDateTolerance(TimeSpan.FromSeconds(2)));
+    }
 }

--- a/Client/Api/Builder/ICamundaCloudClientBuilder.cs
+++ b/Client/Api/Builder/ICamundaCloudClientBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Zeebe.Client.Api.Builder;
 
@@ -81,6 +82,23 @@ public interface ICamundaCloudClientBuilderFinalStep
     /// <param name="path">the path where to store the credentials, if null it uses the default "~/.zeebe" .</param>
     /// <returns>the fluent ICamundaCloudClientBuilderFinalStep.</returns>
     ICamundaCloudClientBuilderFinalStep UsePersistedStoragePath(string path);
+
+    /// <summary>
+    ///     Disables credentials cache persitence to file system.
+    /// </summary>
+    /// <returns>the fluent ICamundaCloudClientBuilderFinalStep.</returns>
+    ICamundaCloudClientBuilderFinalStep DisableCredentialsCachePersistence();
+
+    /// <summary>
+    ///     Use AccessToken due date tolerance to refresh token before due date.
+    ///     To compensate network latency and prevent server side rejection when the
+    ///     AccessToken due date is too close to UTC now, this option allows you to
+    ///     add a tolerance period to refresh the token slightly before due date.
+    ///     e.g. TimeSpan.FromSeconds(2) will refresh the token 2 seconds before due date.
+    /// </summary>
+    /// <param name="tolerance">The tolerance to apply to token due date</param>
+    /// <returns>The final step in building a CamundaCloudTokenProvider.</returns>
+    ICamundaCloudClientBuilderFinalStep UseAccessTokenDueDateTolerance(TimeSpan tolerance);
 
     /// <summary>
     ///     The IZeebeClient, which is setup entirely to talk with the defined Camunda Cloud cluster.

--- a/Client/Api/Builder/ICamundaCloudClientBuilder.cs
+++ b/Client/Api/Builder/ICamundaCloudClientBuilder.cs
@@ -84,7 +84,7 @@ public interface ICamundaCloudClientBuilderFinalStep
     ICamundaCloudClientBuilderFinalStep UsePersistedStoragePath(string path);
 
     /// <summary>
-    ///     Disables credentials cache persitence to file system.
+    ///     Disables credentials cache persistence to file system.
     /// </summary>
     /// <returns>the fluent ICamundaCloudClientBuilderFinalStep.</returns>
     ICamundaCloudClientBuilderFinalStep DisableCredentialsCachePersistence();

--- a/Client/Api/Builder/ICamundaCloudTokenProviderBuilder.cs
+++ b/Client/Api/Builder/ICamundaCloudTokenProviderBuilder.cs
@@ -68,7 +68,7 @@ public interface ICamundaCloudTokenProviderBuilderFinalStep
     ICamundaCloudTokenProviderBuilderFinalStep UsePath(string path);
 
     /// <summary>
-    ///     Disables credentials cache persitence to file system.
+    ///     Disables credentials cache persistence to file system.
     /// </summary>
     /// <returns>The final step in building a CamundaCloudTokenProvider.</returns>
     ICamundaCloudTokenProviderBuilderFinalStep DisableCredentialsCachePersistence();

--- a/Client/Api/Builder/ICamundaCloudTokenProviderBuilder.cs
+++ b/Client/Api/Builder/ICamundaCloudTokenProviderBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System;
 using Zeebe.Client.Impl.Builder;
 
 namespace Zeebe.Client.Api.Builder;
@@ -65,6 +66,23 @@ public interface ICamundaCloudTokenProviderBuilderFinalStep
     /// <param name="path">The path where to store the credentials.</param>
     /// <returns>The final step in building a CamundaCloudTokenProvider.</returns>
     ICamundaCloudTokenProviderBuilderFinalStep UsePath(string path);
+
+    /// <summary>
+    ///     Disables credentials cache persitence to file system.
+    /// </summary>
+    /// <returns>The final step in building a CamundaCloudTokenProvider.</returns>
+    ICamundaCloudTokenProviderBuilderFinalStep DisableCredentialsCachePersistence();
+
+    /// <summary>
+    ///     Use AccessToken due date tolerance to refresh token before due date.
+    ///     To compensate network latency and prevent server side rejection when the
+    ///     AccessToken due date is too close to UTC now, this option allows you to
+    ///     add a tolerance period to refresh the token slightly before due date.
+    ///     e.g. TimeSpan.FromSeconds(2) will refresh the token 2 seconds before due date.
+    /// </summary>
+    /// <param name="tolerance">The tolerance to apply to token due date</param>
+    /// <returns>The final step in building a CamundaCloudTokenProvider.</returns>
+    ICamundaCloudTokenProviderBuilderFinalStep UseAccessTokenDueDateTolerance(TimeSpan tolerance);
 
     /// <summary>
     ///     Builds the CamundaCloudTokenProvider, which can be used by the ZeebeClient to

--- a/Client/Impl/Builder/CamundaCloudClientBuilder.cs
+++ b/Client/Impl/Builder/CamundaCloudClientBuilder.cs
@@ -67,6 +67,18 @@ public class CamundaCloudClientBuilder : ICamundaCloudClientBuilder, ICamundaClo
         return this;
     }
 
+    public ICamundaCloudClientBuilderFinalStep DisableCredentialsCachePersistence()
+    {
+        _ = camundaCloudTokenProviderBuilder.DisableCredentialsCachePersistence();
+        return this;
+    }
+
+    public ICamundaCloudClientBuilderFinalStep UseAccessTokenDueDateTolerance(TimeSpan tolerance)
+    {
+        _ = camundaCloudTokenProviderBuilder.UseAccessTokenDueDateTolerance(tolerance);
+        return this;
+    }
+
     public IZeebeClient Build()
     {
         return ZeebeClient.Builder()

--- a/Client/Impl/Builder/CamundaCloudClientBuilder.cs
+++ b/Client/Impl/Builder/CamundaCloudClientBuilder.cs
@@ -67,12 +67,14 @@ public class CamundaCloudClientBuilder : ICamundaCloudClientBuilder, ICamundaClo
         return this;
     }
 
+    /// <inheritdoc/>
     public ICamundaCloudClientBuilderFinalStep DisableCredentialsCachePersistence()
     {
         _ = camundaCloudTokenProviderBuilder.DisableCredentialsCachePersistence();
         return this;
     }
 
+    /// <inheritdoc/>
     public ICamundaCloudClientBuilderFinalStep UseAccessTokenDueDateTolerance(TimeSpan tolerance)
     {
         _ = camundaCloudTokenProviderBuilder.UseAccessTokenDueDateTolerance(tolerance);

--- a/Client/Impl/Builder/CamundaCloudTokenProvider.cs
+++ b/Client/Impl/Builder/CamundaCloudTokenProvider.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -57,6 +56,7 @@ public class CamundaCloudTokenProvider : IAccessTokenSupplier, IDisposable
     {
         httpClient.Dispose();
         httpMessageHandler.Dispose();
+        this.persistedAccessTokenCache.Dispose();
     }
 
     public static CamundaCloudTokenProviderBuilder Builder()

--- a/Client/Impl/Builder/CamundaCloudTokenProvider.cs
+++ b/Client/Impl/Builder/CamundaCloudTokenProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -31,10 +32,13 @@ public class CamundaCloudTokenProvider : IAccessTokenSupplier, IDisposable
         string clientSecret,
         string audience,
         string path = null,
-        ILoggerFactory loggerFactory = null)
+        ILoggerFactory loggerFactory = null,
+        bool persistedCredentialsCacheEnabled = true,
+        TimeSpan accessTokenDueDateTolerance = default)
     {
         persistedAccessTokenCache = new PersistedAccessTokenCache(path ?? ZeebeRootPath, FetchAccessToken,
-            loggerFactory?.CreateLogger<PersistedAccessTokenCache>());
+            loggerFactory?.CreateLogger<PersistedAccessTokenCache>(),
+            persistedCredentialsCacheEnabled, accessTokenDueDateTolerance);
         logger = loggerFactory?.CreateLogger<CamundaCloudTokenProvider>();
         this.authServer = authServer;
         this.clientId = clientId;

--- a/Client/Impl/Builder/CamundaCloudTokenProviderBuilder.cs
+++ b/Client/Impl/Builder/CamundaCloudTokenProviderBuilder.cs
@@ -19,6 +19,8 @@ namespace Zeebe.Client.Impl.Builder
         private string clientSecret;
         private ILoggerFactory loggerFactory;
         private string path;
+        private bool persistedCredentialsCacheEnabled = true;
+        private TimeSpan accessTokenDueDateTolerance = TimeSpan.Zero;
 
         /// <inheritdoc />
         public ICamundaCloudTokenProviderBuilder UseLoggerFactory(ILoggerFactory loggerFactory)
@@ -51,6 +53,25 @@ namespace Zeebe.Client.Impl.Builder
         }
 
         /// <inheritdoc />
+        public ICamundaCloudTokenProviderBuilderFinalStep DisableCredentialsCachePersistence()
+        {
+            this.persistedCredentialsCacheEnabled = false;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public ICamundaCloudTokenProviderBuilderFinalStep UseAccessTokenDueDateTolerance(TimeSpan tolerance)
+        {
+            if (tolerance < TimeSpan.Zero)
+            {
+                throw new ArgumentException("AccessToken due date tolerance must be a positive time span", nameof(tolerance));
+            }
+
+            this.accessTokenDueDateTolerance = tolerance;
+            return this;
+        }
+
+        /// <inheritdoc />
         public CamundaCloudTokenProvider Build()
         {
             return new CamundaCloudTokenProvider(
@@ -59,7 +80,9 @@ namespace Zeebe.Client.Impl.Builder
                 clientSecret,
                 audience,
                 path,
-                loggerFactory);
+                loggerFactory,
+                persistedCredentialsCacheEnabled,
+                accessTokenDueDateTolerance);
         }
 
         /// <inheritdoc />

--- a/Client/Impl/Misc/PersistedAccessTokenCache.cs
+++ b/Client/Impl/Misc/PersistedAccessTokenCache.cs
@@ -1,9 +1,10 @@
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Zeebe.Client.Impl.Misc;
 
@@ -15,83 +16,146 @@ public class PersistedAccessTokenCache : IAccessTokenCache
     //     Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".zeebe");
 
     private readonly ILogger<PersistedAccessTokenCache> logger;
-
     private readonly string tokenStoragePath;
+    private readonly bool persistedCredentialsCacheEnabled;
+    private readonly SemaphoreSlim mutex = new SemaphoreSlim(1, 1);
+    private readonly TimeSpan dueDateTolerance;
 
-    public PersistedAccessTokenCache(string path, IAccessTokenCache.AccessTokenResolverAsync fetcherAsync,
-        ILogger<PersistedAccessTokenCache> logger = null)
+    public PersistedAccessTokenCache(
+        string path,
+        IAccessTokenCache.AccessTokenResolverAsync fetcherAsync,
+        ILogger<PersistedAccessTokenCache> logger = null,
+        bool persistedCredentialsCacheEnabled = true,
+        TimeSpan dueDateTolerance = default)
     {
-        var directoryInfo = Directory.CreateDirectory(path);
-        if (!directoryInfo.Exists)
+        if (persistedCredentialsCacheEnabled)
         {
-            throw new IOException("Expected to create '~/.zeebe/' directory, but failed to do so.");
+            var directoryInfo = Directory.CreateDirectory(path);
+            if (!directoryInfo.Exists)
+            {
+                throw new IOException("Expected to create '~/.zeebe/' directory, but failed to do so.");
+            }
         }
 
-        tokenStoragePath = path;
+        this.tokenStoragePath = path;
+        this.persistedCredentialsCacheEnabled = persistedCredentialsCacheEnabled;
         this.logger = logger;
-        accessTokenFetcherAsync = fetcherAsync;
-        CachedCredentials = new Dictionary<string, AccessToken>();
+        this.accessTokenFetcherAsync = fetcherAsync;
+        this.CachedCredentials = new Dictionary<string, AccessToken>();
+        this.dueDateTolerance = dueDateTolerance;
     }
 
     private static string ZeebeTokenFileName => "credentials";
+
     private Dictionary<string, AccessToken> CachedCredentials { get; set; }
-    private string TokenFileName => Path.Combine(tokenStoragePath, ZeebeTokenFileName);
+
+    private string TokenFileName => Path.Combine(this.tokenStoragePath, ZeebeTokenFileName);
 
     public async Task<string> Get(string audience)
     {
-        // check in memory
-        if (CachedCredentials.TryGetValue(audience, out var currentAccessToken))
+        // shortcut sync lock if in-memory token is valid (read-only)
+        if (this.CachedCredentials.TryGetValue(audience, out var currentAccessToken)
+            && this.IsValid(currentAccessToken))
         {
-            logger?.LogTrace("Use in memory access token");
-            return await GetValidToken(audience, currentAccessToken);
+            this.logger?.LogTrace("Use in memory access token");
+            return currentAccessToken.Token;
         }
 
-        // check if token file exists
-        var useCachedFileToken = File.Exists(TokenFileName);
-        if (useCachedFileToken)
+        // Secure concurrent access to token cache
+        // and prevent race condition when accessing the file system.
+        await this.mutex.WaitAsync().ConfigureAwait(false);
+        try
         {
-            logger?.LogTrace("Read cached access token from {TokenFileName}", TokenFileName);
-            // read token
-            var content = await File.ReadAllTextAsync(TokenFileName);
-            CachedCredentials = JsonConvert.DeserializeObject<Dictionary<string, AccessToken>>(content);
-            if (CachedCredentials.TryGetValue(audience, out currentAccessToken))
+            return await this.GetOrRefreshAccessToken(audience).ConfigureAwait(false);
+        }
+        finally
+        {
+            this.mutex.Release();
+        }
+    }
+
+    private async Task<string> GetOrRefreshAccessToken(string audience)
+    {
+        // check in memory
+        if (this.CachedCredentials.TryGetValue(audience, out var currentAccessToken))
+        {
+            this.logger?.LogTrace("Use in memory access token");
+            return await this.GetValidToken(audience, currentAccessToken);
+        }
+
+        if (this.persistedCredentialsCacheEnabled)
+        {
+            // check if token file exists
+            var useCachedFileToken = File.Exists(this.TokenFileName);
+            if (useCachedFileToken)
             {
-                logger?.LogTrace("Found access token in credentials file");
-                return await GetValidToken(audience, currentAccessToken);
+                this.logger?.LogTrace("Read cached access token from {TokenFileName}", this.TokenFileName);
+                // read token
+                var content = await File.ReadAllTextAsync(this.TokenFileName);
+                this.CachedCredentials = JsonConvert.DeserializeObject<Dictionary<string, AccessToken>>(content);
+                if (this.CachedCredentials.TryGetValue(audience, out currentAccessToken))
+                {
+                    logger?.LogTrace("Found access token in credentials file");
+                    return await this.GetValidToken(audience, currentAccessToken);
+                }
             }
         }
 
         // fetch new token
-        var newAccessToken = await FetchNewAccessToken(audience);
+        var newAccessToken = await this.FetchNewAccessToken(audience);
         return newAccessToken.Token;
+    }
+
+    private bool IsValid(AccessToken accessToken)
+    {
+        // add {dueDateTolerance} to UTC now to compensate network latency
+        // and prevent server rejection if due date is too close to now.
+        // Meaning that token will be refreshed {dueDateTolerance} before expiration.
+        var now = DateTimeOffset.UtcNow.Add(this.dueDateTolerance).ToUnixTimeMilliseconds();
+        var dueDate = accessToken.DueDate;
+
+        if (now < dueDate)
+        {
+            return true;
+        }
+
+        var tolerance = (this.dueDateTolerance == default) ? string.Empty : $"(-{this.dueDateTolerance})";
+        this.logger?.LogTrace(
+            "Access token is no longer valid (now: {Now} > dueTime{DueDateTolerance}: {DueTime}), request new one",
+            now,
+            tolerance,
+            dueDate);
+
+        return false;
     }
 
     private async Task<string> GetValidToken(string audience, AccessToken currentAccessToken)
     {
-        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        var dueDate = currentAccessToken.DueDate;
-        if (now < dueDate)
+        if (this.IsValid(currentAccessToken))
         {
             // still valid
             return currentAccessToken.Token;
         }
 
-        logger?.LogTrace("Access token is no longer valid (now: {Now} > dueTime: {DueTime}), request new one", now,
-            dueDate);
-        var newAccessToken = await FetchNewAccessToken(audience);
+        var newAccessToken = await this.FetchNewAccessToken(audience);
         return newAccessToken.Token;
     }
 
     private async Task<AccessToken> FetchNewAccessToken(string audience)
     {
-        var newAccessToken = await accessTokenFetcherAsync();
-        CachedCredentials[audience] = newAccessToken;
-        WriteCredentials();
+        var newAccessToken = await this.accessTokenFetcherAsync();
+        this.CachedCredentials[audience] = newAccessToken;
+
+        if (this.persistedCredentialsCacheEnabled)
+        {
+            this.WriteCredentials();
+        }
+
         return newAccessToken;
     }
 
     private void WriteCredentials()
     {
-        File.WriteAllText(TokenFileName, JsonConvert.SerializeObject(CachedCredentials));
+        File.WriteAllText(this.TokenFileName, JsonConvert.SerializeObject(this.CachedCredentials));
     }
 }


### PR DESCRIPTION
- Introduces a `DisableCredentialsCachePersistence()` builder method in client `CamundaCloudClientBuilder` to prevent persisting token cache in file system. The goal is to allow users to setup an in-memory only cache for e.g. serverless usage of the client.
- Fixes concurrent access issue to `AccessToken` cache. The introduction of a `SemaphoreSlim` will protect concurrent accesses to the dictionary and the file system, and prevent concurrent token fetching. The choice of `SemaphoreSlim` is done because it is the lock mechanism that fits the best with async/await model. The implementation is optimized to prevent locking when a valid token is in cache.
- Introduces a `UseAccessTokenDueDateTolerance(TimeSpan tolerance)` builder method in client `CamundaCloudClientBuilder`. The goal of this option is to allow the user to refresh the `AccessToken` slightly before expiration to prevent that, because of network latency, a token considered valid by the client is expired when validated by the authorization server.

This change also solves partially issue 637. But the issue rather mentions introducing different implementation of the `IAccessTokenCache`. This approach is more impacting for the `PersistedAccessTokenCache` for just an in-memory only alternative, as this implementation already have its in-memory cache. To limit the impact, I chose to only improve the existing implementation.

closes #415 #642
