### PR TITLE
feat: Add CancellationToken to job worker and handler

### DIFF
--- a/Client.Examples/BackgroundServiceExample.cs.md
+++ b/Client.Examples/BackgroundServiceExample.cs.md
@@ -1,0 +1,51 @@
+## Using Job Worker In BackgroundService Example
+
+This example showcases how Zeebe job worker can be used in ASP.NET BackgroundService with asynchronous job handler method.
+
+It uses the job handler delegate variant that supports injection of the job worker cancellation token.
+
+It also passes the BackroundService stopping token to the job worker, so that cancellation of the background service is propagated to the worker.
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Zeebe.Client;
+using Zeebe.Client.Api.Responses;
+using Zeebe.Client.Api.Worker;
+
+namespace MyWebApplication;
+
+public class ZeebeBackgroundService : BackgroundService
+{
+    private readonly IZeebeClient client;
+
+    public ZeebeBackgroundService(IZeebeClient client)
+    {
+        this.client = client;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        this.client.NewWorker()
+            .JobType("My-Job")
+            .Handler(HandleJobAsync)
+            .MaxJobsActive(5)
+            .Name(Environment.MachineName)
+            .AutoCompletion()
+            .PollInterval(TimeSpan.FromSeconds(1))
+            .Timeout(TimeSpan.FromSeconds(10))
+            .PollingTimeout(TimeSpan.FromSeconds(30))
+            .Open(stoppingToken); // Passes the stopping token to the worker to gracefully cancel it in case of background service cancellation.
+
+        return Task.CompletedTask;
+    }
+
+    private static async Task HandleJobAsync(IJobClient jobClient, IJob job, CancellationToken cancellationToken)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+
+        await jobClient
+            .NewCompleteJobCommand(job)
+            .Send(cancellationToken);
+    }
+}
+```

--- a/Client/Api/Worker/IJobWorkerBuilderStep1.cs
+++ b/Client/Api/Worker/IJobWorkerBuilderStep1.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Zeebe.Client.Api.Commands;
 using Zeebe.Client.Api.Responses;
@@ -43,8 +44,9 @@ public delegate void JobHandler(IJobClient client, IJob activatedJob);
 /// </summary>
 /// <param name="client">the job client to complete or fail the job.</param>
 /// <param name="activatedJob">the job, which was activated by the worker.</param>
+/// <param name="cancellationToken">the token to cancel the job handler.</param>
 /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
-public delegate Task AsyncJobHandler(IJobClient client, IJob activatedJob);
+public delegate Task AsyncJobHandler(IJobClient client, IJob activatedJob, CancellationToken cancellationToken = default);
 
 public interface IJobWorkerBuilderStep2
 {
@@ -247,6 +249,7 @@ public interface IJobWorkerBuilderStep3 : ITenantIdsCommandStep<IJobWorkerBuilde
     /// <summary>
     ///     Open the worker and start to work on available tasks.
     /// </summary>
+    /// <param name="cancellationToken">the token to cancel the job worker.</param>
     /// <returns>the worker.</returns>
-    IJobWorker Open();
+    IJobWorker Open(CancellationToken cancellationToken = default);
 }

--- a/Client/Impl/Worker/JobWorker.cs
+++ b/Client/Impl/Worker/JobWorker.cs
@@ -39,7 +39,7 @@ public sealed class JobWorker : IJobWorker
     private readonly StreamActivatedJobsRequest streamActivateJobsRequest;
     private readonly bool autoCompletion;
     private readonly JobActivator jobActivator;
-    private readonly AsyncJobHandler jobHandler;
+    private readonly AsyncJobHandlerWithCancellationToken jobHandler;
     private readonly JobWorkerBuilder jobWorkerBuilder;
     private readonly ILogger<JobWorker> logger;
     private readonly int maxJobsActive;

--- a/Client/Impl/Worker/JobWorkerBuilder.cs
+++ b/Client/Impl/Worker/JobWorkerBuilder.cs
@@ -31,7 +31,7 @@ public class JobWorkerBuilder(
     ILoggerFactory loggerFactory = null)
     : IJobWorkerBuilderStep1, IJobWorkerBuilderStep2, IJobWorkerBuilderStep3
 {
-    private AsyncJobHandler asyncJobHandler;
+    private AsyncJobHandlerWithCancellationToken asyncJobHandler;
     private bool autoCompletion;
     private TimeSpan pollInterval;
     public bool GrpcStreamEnabled { get; private set; }
@@ -56,6 +56,12 @@ public class JobWorkerBuilder(
     }
 
     public IJobWorkerBuilderStep3 Handler(AsyncJobHandler handler)
+    {
+        asyncJobHandler = (c, j, cts) => handler(c, j);
+        return this;
+    }
+
+    public IJobWorkerBuilderStep3 Handler(AsyncJobHandlerWithCancellationToken handler)
     {
         asyncJobHandler = handler;
         return this;
@@ -157,7 +163,7 @@ public class JobWorkerBuilder(
         return worker;
     }
 
-    internal AsyncJobHandler Handler()
+    internal AsyncJobHandlerWithCancellationToken Handler()
     {
         return asyncJobHandler;
     }

--- a/Client/Impl/Worker/JobWorkerBuilder.cs
+++ b/Client/Impl/Worker/JobWorkerBuilder.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GatewayProtocol;
 using Microsoft.Extensions.Logging;
@@ -50,7 +51,7 @@ public class JobWorkerBuilder(
 
     public IJobWorkerBuilderStep3 Handler(JobHandler handler)
     {
-        asyncJobHandler = (c, j) => Task.Run(() => handler.Invoke(c, j));
+        asyncJobHandler = (c, j, cts) => Task.Run(() => handler.Invoke(c, j), cts);
         return this;
     }
 
@@ -147,11 +148,11 @@ public class JobWorkerBuilder(
         return this;
     }
 
-    public IJobWorker Open()
+    public IJobWorker Open(CancellationToken cancellationToken = default)
     {
         var worker = new JobWorker(this);
 
-        worker.Open();
+        worker.Open(cancellationToken);
 
         return worker;
     }

--- a/Client/Impl/Worker/JobWorkerBuilder.cs
+++ b/Client/Impl/Worker/JobWorkerBuilder.cs
@@ -51,13 +51,13 @@ public class JobWorkerBuilder(
 
     public IJobWorkerBuilderStep3 Handler(JobHandler handler)
     {
-        asyncJobHandler = (c, j, cts) => Task.Run(() => handler.Invoke(c, j), cts);
+        asyncJobHandler = (jobClient, job, cancellationToken) => Task.Run(() => handler.Invoke(jobClient, job), cancellationToken);
         return this;
     }
 
     public IJobWorkerBuilderStep3 Handler(AsyncJobHandler handler)
     {
-        asyncJobHandler = (c, j, cts) => handler(c, j);
+        asyncJobHandler = (jobClient, job, cancellationToken) => handler(jobClient, job);
         return this;
     }
 


### PR DESCRIPTION
Introduces an optional `CancellationToken` argument to `JobWorker.Open()` method to inject a host cancellation token and expose token to `AsyncJobHandler` delegate.

closes #519
