### PR TITLE
build: use Renovate native automerge instead of custom merge job

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -27,19 +27,4 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release
     - name: Test
-      run: dotnet test Client.IntegrationTests      
-  auto-merge:
-    name: Auto-merge dependabot PRs
-    runs-on: ubuntu-latest
-    needs: [ unit-test, integration-test ]
-    if: github.repository == 'camunda-community-hub/zeebe-client-csharp' && (github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]')
-    permissions:
-      checks: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-      - id: merge
-        name: Merge PR
-        run: gh pr merge ${{ github.event.pull_request.number }} --merge
-        env:
-          GITHUB_TOKEN: "${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}"
+      run: dotnet test Client.IntegrationTests

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "automerge": true,
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary
- Removes the hand-rolled `auto-merge` job in `pull-request-ci.yaml` that shelled out to `gh pr merge` using a dedicated `AUTO_MERGE_GITHUB_TOKEN` PAT, gated on the actor being `dependabot[bot]`/`renovate[bot]`.
- Enables `automerge` + `platformAutomerge` in `renovate.json`, so Renovate PRs merge via GitHub's native "Enable auto-merge" once required checks pass.

## Why
The custom job only merges when the PR's last-triggering actor is dependabot/renovate, so a human-authored fix commit on a Renovate PR never triggers it and the PR can sit unmerged even after CI is green. This is a companion change to setting up branch protection (requiring `Run unit tests` / `Run integration tests`) and enabling "Allow auto-merge" at the repo level, applied separately via the GitHub API.

The `AUTO_MERGE_GITHUB_TOKEN` secret is unused after this change and can be removed once this is confirmed working.

## Test plan
- [ ] Confirm `Run unit tests` and `Run integration tests` are required status checks on `main`
- [ ] Confirm "Allow auto-merge" is enabled for the repo
- [ ] Verify a subsequent Renovate PR auto-merges once checks pass